### PR TITLE
feat: 강사 인증 코드 설정 설계 및 구현

### DIFF
--- a/auth/signup.py
+++ b/auth/signup.py
@@ -1,4 +1,4 @@
-from constants import MEMBER_PATH, INSTRUCTOR_PATH, INSTRUCTOR_CODE, USER_TYPE_INSTRUCTOR
+from constants import MEMBER_PATH, INSTRUCTOR_PATH, USER_TYPE_INSTRUCTOR, INST_CODE_PATH
 from models import Instructor, Member
 from file_handler import read_csv, write_csv
 import views
@@ -7,9 +7,12 @@ import re
 def get_instructor_code():
     while True:
         code = input("인증코드를 입력하세요 >>")
+        rows = read_csv(INST_CODE_PATH)
+        if not rows:
+            views.print_error("인증코드가 설정되지 않았습니다.")
+            continue
 
-        # 공백 검사 + 코드 일치 검사
-        if (code != code.strip()) or (code != INSTRUCTOR_CODE):
+        if (code != code.strip()) or (code != rows[0]["current_code"]):
             views.print_error("올바른 인증 코드가 아닙니다.")
             continue
         break

--- a/constants.py
+++ b/constants.py
@@ -18,6 +18,7 @@ MEMBER_PATH = 'data/members.csv'
 INSTRUCTOR_PATH = 'data/instructors.csv'
 RESERVATION_PATH = 'data/reservations.csv'
 DATETIME_PATH = 'data/datetime.csv'
+INST_CODE_PATH = 'data/instructor_code.csv'
 
 ## Instructor auth code
 INSTRUCTOR_CODE = '0000'

--- a/constants.py
+++ b/constants.py
@@ -12,6 +12,8 @@ NO_DUPLICATION = -3
 USER_TYPE_MEMBER = 'm'  
 ## Instructor    
 USER_TYPE_INSTRUCTOR = 'n'
+## Admin
+USER_TYPE_ADMIN = 'a'
 
 ##file_path
 MEMBER_PATH = 'data/members.csv'

--- a/controllers/admin_controller.py
+++ b/controllers/admin_controller.py
@@ -1,0 +1,37 @@
+import re
+from utils import read_csv, write_csv
+from constants import *
+from datetime import datetime
+
+def set_instructor_code(current_datetime:datetime)->None:
+    rows = read_csv(INST_CODE_PATH)
+    if not rows:
+        last_modified_date = f"{current_datetime:%y%m%d}"
+        current_code = "0000"
+        write_csv(INST_CODE_PATH, [{"last_modified_date": last_modified_date, "current_code": current_code}])
+    else:
+        last_modified_date = rows[0]["last_modified_date"]
+        current_code = rows[0]["current_code"]
+
+    print("───────────────────────────────────────")
+    print("[ 강사 인증 코드 설정 ]")
+    print("───────────────────────────────────────")
+    print(f"현재 인증 코드: {current_code}")
+    new_code = input("새로운 인증 코드를 입력하세요 (4자리 숫자) >> ")
+
+    if not re.fullmatch(r"^\d{4}$", new_code):
+        print("[오류] 올바른 인증코드가 아닙니다.")
+        return
+    if new_code == current_code:
+        print("[오류] 현재 인증 코드와 동일한 값으로는 변경할 수 없습니다.")
+        return
+    if f"{current_datetime:%y%m}" == last_modified_date[:4]:
+        next_month = current_datetime.month + 1
+        next_year = current_datetime.year
+        if next_month > 12: next_month = 1; next_year += 1
+        print(f"[오류] 이번 달에는 이미 인증 코드를 변경했습니다. 다음 변경 가능 시점: {next_year}년 {next_month}월 1일부터")
+        return
+
+    write_csv(INST_CODE_PATH, [{"last_modified_date": f"{current_datetime:%y%m%d}", "current_code": new_code}])
+    print("인증 코드가 정상적으로 변경되었습니다.")
+    return


### PR DESCRIPTION
## ✨ 작업 요약
- 강사 인증 코드 설정을 구현했습니다.
- 테스트를 해보기 위해서 강사 메뉴 및 메인, 로그인 등을 수정했는데 제 파트가 아니라 일단 커밋은 안했습니다 잘 돌아감

## 📍 설계
함수명 | 리턴형
-- | --
set_instructor_code(current_datetime: datetime) | None

관리자 메뉴에서 강사 인증 코드 설정을 담당. 입력값을 검증하고 유효할 경우 파일을 갱신함.

### instructor_code.csv 필드

필드명 | 타입 | 설명
-- | -- | --
last_modified_date | string | 마지막으로 인증 코드를 변경한 날짜 (YYMMDD 형식)
current_code | string | 현재 유효한 강사 인증 코드 (4자리 숫자 문자열)


### 변수 정의

변수명 | 타입 | 의미 설명 | 구분
-- | -- | -- | --
last_modified_date | string | 마지막으로 인증 코드를 변경한 날짜 (YYMMDD 형식) | instructor_code.csv 파일 내부 값
current_code | string | 현재 유효한 강사 인증 코드 (4자리 숫자 문자열) | instructor_code.csv 파일 내부 값
new_code | string | 새로 입력받은 인증 코드 | 직접 정의 후 사용자에게 입력받음
current_datetime | datetime | 현재 날짜와 시간 (%y%m%d,%H:%M) | 인자로 받는 값

### 파일 읽기
- `utils.py` 내에 정의된 `read_csv(filepath)` 함수를 사용하여 `data/instructor_code.csv`에서 `last_modified_date`와 `current_code`를 읽어온다.
 - `data/instructor_code.csv` 파일 내 값이 없으면 현재 날짜와 `0000`을 기본값으로 사용한다.

### 입출력 인터페이스
````
───────────────────────────────────────
[ 강사 인증 코드 설정 ]
───────────────────────────────────────
현재 인증 코드: {current_code}
새로운 인증 코드를 입력하세요 (4자리 숫자) >>
````
- 입력값: 4자리 숫자 문자열
- 출력값: 성공/오류 메시지 및 관리자 메뉴로 복귀</p>

### 조건 처리 로직
1. **문법 검증** : `re.fullmatch`를 이용하여 정규표현식 `^\d{4}$` 만족 여부 검사  
   - 실패 시:  
     ```
     [오류] 올바른 인증코드가 아닙니다.
     ```

2. **의미 검증**  
   - 기존 코드와 동일할 경우: `new_code == current_code` → 오류 메시지 출력 후 관리자 메뉴 복귀
     ```
     [오류] 현재 인증 코드와 동일한 값으로는 변경할 수 없습니다.
     ```
   - 동일한 연도·월에 이미 변경한 경우:  `f"{current_datetime:%y%m}" == last_modified_date[:4]`→ 오류 메시지 출력 후 관리자 메뉴 복귀
     ```
     [오류] 이번 달에는 이미 인증 코드를 변경했습니다.
     다음 변경 가능 시점: {YYYY}년 {MM}월 1일부터
     ```

3. **정상 처리**:
    - `utils.py` 내에 정의된 `write_csv(filepath, data_list)` 함수를 사용하여, `f"{current_datetime:%y%m%d}", new_code`의 형식으로 `data/instructor_code.csv`의 내용을 덮어쓴다.
    - 성공 메시지 출력 후 관리자 메뉴로 복귀
      ```
      인증 코드가 정상적으로 변경되었습니다.
      ```