### PR TITLE
fix: 사물함 개수 0개/빈 CSV 예외 처리 및 검사 보고서 테스트케이스 확인함 + 추가로 9,10번 사물함 사용 중일 …

### DIFF
--- a/data/lockers.csv
+++ b/data/lockers.csv
@@ -1,0 +1,5 @@
+id,user_id,expire_date,locker_status,extended
+01,20230001,24/06/01,occupied,False
+02,,24/06/01,empty,False
+03,20230002,24/06/10,occupied,True
+04,,24/06/01,empty,False 


### PR DESCRIPTION
…때 사물함 개수 설정을 3개만 하면 9,10은 자동으로 앞 번호로 설정됨 + lockers.csv 구현하고 사물함 개수 0개 설정해도 헤더 존재하도록 고침

## ✨ 작업 요약
-사물함 개수 설정 및 lockers.csv 관리 기능의 모든 입력 검증을 강화하여, 잘못된 입력(선행 0, 공백, 특수문자, 한글, 실수, 음수 등)에 대해 정확히 오류 메시지를 출력하도록 개선
- 사물함 개수를 0개로 설정하거나 lockers.csv가 완전히 비어 있을 때에도, 헤더가 항상 남도록 예외 처리(빈 파일/헤더 유실 시 발생하던 오류 완전 방지)
- file_handler.py는 수정하지 않고, 사물함 관련 코드(controllers/locker_controller.py)에서만 안전하게 처리하도록 구현
- 모든 관리자 메뉴 및 사물함 관련 기능이 테스트케이스 요구사항과 100% 일치하도록 동작 확인 및 보완

## 📂 변경된 파일
- controllers/locker_controller.py
- data/lockers.csv