### PR TITLE
사물함 남은 기간 계산 로직 수정

### DIFF
--- a/controllers/locker_controller.py
+++ b/controllers/locker_controller.py
@@ -61,9 +61,10 @@ class LockerSystem:
         """남은 일수를 반환합니다."""
         if locker.user_id != "":
             expire_date = datetime.strptime(locker.expire_date, "%y%m%d")
-            remaining_days = expire_date - current_datetime
+            current_date = datetime.strptime(current_datetime.strftime("%y%m%d"), "%y%m%d")
+            remaining_days = expire_date - current_date
 
-            if(remaining_days.days<0):
+            if (remaining_days.days<0):
                 locker.user_id = ""
                 locker.expire_date = ''
             


### PR DESCRIPTION
## ✨ 작업 요약
- `get_remaining_days` 함수에서 datetime(날짜+시간)을 date(날짜)로 변환하여 남은 기간 계산
- 기존: datetime 객체의 시간 정보까지 포함하여 계산되어 정확하지 않았음
  - 예: 현재 시간이 3월 20일 15:00이고 만료일이 3월 21일인 경우, 시간 차이로 인해 하루가 아닌 0.375일로 계산됨 → 0일로 표시됨
- 수정: strftime과 strptime을 사용하여 날짜 정보만 추출하여 정확한 일수 계산
  - 날짜만 비교하여 정확한 일수 계산 가능